### PR TITLE
Failing default installation on CentOS

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -4,7 +4,7 @@ default['zendserver']['zsmanage']  = '/usr/local/zend/bin/zs-manage'
 #URL needs to have trailing slash
 default['zendserver']['url'] = 'http://repos.zend.com/zend-server/'
 default['zendserver']['basedirdeb'] = 'deb_apache2.4'
-default['zendserver']['basedirrpm'] = 'rpm'
+default['zendserver']['basedirrpm'] = 'rpm_apache2.4'
 
 default['zendserver']['version'] = '8.0'
 default['zendserver']['phpversion'] = '5.6'

--- a/recipes/applydirectives.rb
+++ b/recipes/applydirectives.rb
@@ -1,3 +1,5 @@
+include_recipe "zendserver::manage"
+
 node[:zendserver][:directives].each do |d, v|
   zendserver_directive d do
     value v


### PR DESCRIPTION
I spent past couple days scratching my head trying to figure out why I can’t install Zend Server on new Vagrant box with CentOS 7.1. After a lot of research I found that one of the repos is not compatibile with Apache 2.4
I kept getting this message:

httpd: Syntax error on line 353 of /etc/httpd/conf/httpd.conf: Syntax error on line 3 of /etc/httpd/conf.d/zendserver_php.conf: Cannot load /usr/local/zend/lib/apache2/libphp5.so into server: /usr/local/zend/lib/apache2/libphp5.so: undefined symbol: unixd_config

I found a link to documentation here:
https://support.zend.com/hc/en-us/articles/205994088-PHP-Does-Not-Load-Under-Apache-Error-undefined-symbol-unixd-config-

And I found that the problem is wrong default basedirrpm in attributes.rb. I mean it's probably ok for older apache vesions but by default everything has been upgraded to 2.4 now and there is no information in docs about setting this value thus making it hard to find

I changed 
default['zendserver']['basedirrpm'] = 'rpm'

To
default['zendserver']['basedirrpm'] = 'rpm_apache2.4'

And everything works fine so I decided to fork the repo and make rpm_apache2.4 a default rpm for the cookbooks in attributes.rb

Also I added include_recipe "zendserver::manage” to applydirectives recipe cause otherwise I had to include it in my Vagrant run list
