### PR TITLE
Move codename into distribution property to fix nginx apt sources list

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -36,7 +36,8 @@ when "debian"
 
   apt_repository "nginx" do
     uri "http://nginx.org/packages/#{node['platform']}" 
-    components [node['lsb']['codename'], 'nginx']
+    components ['nginx']
+    distribution node['lsb']['codename']
     key "http://nginx.org/keys/nginx_signing.key"
     only_if { node[:zendserver][:nginx] }
   end


### PR DESCRIPTION
I'm proposing a change to the ZendServerChefCookbook when installing with nginx.

Without the distribution property value, the apt_repository resource is producing the following entry in the sources list:

> deb      "http://nginx.org/packages/ubuntu" trusty trusty nginx

This entry is resulting in `Failed to fetch http://nginx.org/packages/ubuntu/dists/trusty/InRelease  Unable to find expected entry 'trusty/binary-amd64/Packages' in Release file (Wrong sources.list entry or malformed file)`

With this change, I'm utilizing the [apt_repository](https://docs.chef.io/resource_apt_repository.html) distribution property, to produce a sources list as described by the [Nginx Debian Packages](https://www.nginx.com/resources/wiki/start/topics/tutorials/install/#official-debian-ubuntu-packages)

> deb      "http://nginx.org/packages/ubuntu" trusty nginx

Thanks so much for your help!